### PR TITLE
Add ldd symlink to gcc package

### DIFF
--- a/pkgs/base.janet
+++ b/pkgs/base.janet
@@ -223,6 +223,8 @@
     make extract_all
     make -j $(nproc)
     make install
+    cd "$out/bin"
+    ln -s /lib/ld-musl-x86_64.so.1 ldd
     ```
     :make-depends [patch-static make-static seed seed-gcc-rt gcc-src]))
 


### PR DESCRIPTION
Since it seems officially supported: https://wiki.musl-libc.org/faq.html#Q:_Where_is_%3Ccode%3Eldd%3C/code%3E%3F